### PR TITLE
Use https instead of http for improved security

### DIFF
--- a/src/tikzit.cpp
+++ b/src/tikzit.cpp
@@ -363,7 +363,7 @@ void Tikzit::checkForUpdates()
     connect(manager, SIGNAL(finished(QNetworkReply*)),
             this, SLOT(updateReply(QNetworkReply*)));
 
-    manager->get(QNetworkRequest(QUrl("http://tikzit.github.io/latest-version.txt")));
+    manager->get(QNetworkRequest(QUrl("https://tikzit.github.io/latest-version.txt")));
 }
 
 void Tikzit::updateReply(QNetworkReply *reply)


### PR DESCRIPTION
I believe it's best practice to use https instead of http for any kind of auto-updaters, even if in our case the possible danger is very much restricted: An attacker can trick users into believing that a newer version is available, and they can cause TikZiT to display semi-arbitrary content in its information box (because the http response is pasted into the box contents without any sanitization).

This pull request proposes to change the offending http url into an https url.

I confirm that, at least on my system running Qt 5.11, the default ssl settings are such that connections to sites with invalid ssl certificates are (silently) rejected.