### PR TITLE
Horizontal scrolling while holding shift

### DIFF
--- a/src/gui/tikzview.cpp
+++ b/src/gui/tikzview.cpp
@@ -150,7 +150,7 @@ void TikzView::wheelEvent(QWheelEvent *event)
             zoomOut();
         }
     } else if (event->modifiers() & Qt::ShiftModifier) {
-        horizontalScrollBar()->setValue(horizontalScrollBar()->value() + event->angleDelta().y());
+        horizontalScrollBar()->setValue(horizontalScrollBar()->value() - event->angleDelta().y());
     }
 }
 

--- a/src/gui/tikzview.cpp
+++ b/src/gui/tikzview.cpp
@@ -149,6 +149,8 @@ void TikzView::wheelEvent(QWheelEvent *event)
         } else if (event->angleDelta().y() < 0) {
             zoomOut();
         }
+    } else if (event->modifiers() & Qt::ShiftModifier) {
+        horizontalScrollBar()->setValue(horizontalScrollBar()->value() + event->angleDelta().y());
     }
 }
 


### PR DESCRIPTION
I am using tikzit with a mouse and keyboard and was missing a convenient method to scroll horizontally.
Other programs like Inkscape or Gimp allow horizontal scrolling with a mouse wheel when holding down the *shift* modifier.
This PR implements just that. I paid attention to not break the "shift-to-scroll" feature (referenced in #53) for trackpads.