### PR TITLE
Fix of close semantics on Mac

### DIFF
--- a/src/gui/mainmenu.cpp
+++ b/src/gui/mainmenu.cpp
@@ -89,8 +89,12 @@ void MainMenu::on_actionOpen_triggered()
 
 void MainMenu::on_actionClose_triggered()
 {
-    if (tikzit->activeWindow() != 0)
+    // Close dialog if it is active.
+    if (tikzit->dialogStatus()) {
+        tikzit->previewWindow()->close();
+    } else if (tikzit->activeWindow() != 0) {
         tikzit->activeWindow()->close();
+    }
 }
 
 void MainMenu::on_actionSave_triggered()

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -147,6 +147,7 @@ void MainWindow::changeEvent(QEvent *event)
 {
     if (event->type() == QEvent::ActivationChange && isActiveWindow()) {
         tikzit->setActiveWindow(this);
+        tikzit->setDialogStatus(false);
         //tikzit->stylePalette()->raise();
     }
     QMainWindow::changeEvent(event);

--- a/src/gui/previewwindow.cpp
+++ b/src/gui/previewwindow.cpp
@@ -157,6 +157,13 @@ void PreviewWindow::setStatus(PreviewWindow::Status status)
     _loader->repaint();
 }
 
+void PreviewWindow::changeEvent(QEvent * event) {
+    if (event->type() == QEvent::ActivationChange && isActiveWindow()) {
+        tikzit->setDialogStatus(true);
+    }
+    QDialog::changeEvent(event);
+}
+
 void PreviewWindow::closeEvent(QCloseEvent *e) {
     QSettings settings("tikzit", "tikzit");
     settings.setValue(QString("geometry-preview-qt") + qVersion(), saveGeometry());

--- a/src/gui/previewwindow.cpp
+++ b/src/gui/previewwindow.cpp
@@ -167,6 +167,7 @@ void PreviewWindow::changeEvent(QEvent * event) {
 void PreviewWindow::closeEvent(QCloseEvent *e) {
     QSettings settings("tikzit", "tikzit");
     settings.setValue(QString("geometry-preview-qt") + qVersion(), saveGeometry());
+    tikzit->setDialogStatus(false);
     QDialog::closeEvent(e);
 }
 

--- a/src/gui/previewwindow.h
+++ b/src/gui/previewwindow.h
@@ -60,6 +60,7 @@ public slots:
     void copyImageToClipboard();
 
 protected:
+    void changeEvent(QEvent* e) override;
     void resizeEvent(QResizeEvent *e) override;
     void showEvent(QShowEvent *e) override;
     void closeEvent(QCloseEvent *e) override;

--- a/src/tikzit.cpp
+++ b/src/tikzit.cpp
@@ -216,6 +216,14 @@ void Tikzit::removeWindow(MainWindow *w)
     }
 }
 
+bool Tikzit::dialogStatus() const {
+    return _dialog_active;
+}
+
+void Tikzit::setDialogStatus(bool active) {
+    _dialog_active = active;
+}
+
 void Tikzit::open()
 {
     QSettings settings("tikzit", "tikzit");
@@ -449,6 +457,7 @@ void Tikzit::makePreview()
         // do nothing.
         _preview->restorePosition();
         _preview->raise();
+        _preview->activateWindow();
     }
 }
 

--- a/src/tikzit.h
+++ b/src/tikzit.h
@@ -109,8 +109,10 @@ public:
     PropertyPalette *propertyPalette() const;
 
     MainWindow *activeWindow() const;
+    bool dialogStatus() const;
     void setActiveWindow(MainWindow *activeWindow);
     void removeWindow(MainWindow *w);
+    void setDialogStatus(bool active);
 
     static QFont LABEL_FONT;
 
@@ -169,6 +171,8 @@ private:
     QVector<QColor> _cols;
     LatexProcess *_latex;
     PreviewWindow *_preview;
+    // _activeWidget to further determine which widget (MainWindow/QDialog) to delete when invoking close shortcut, for Mac, invoking CMD+W should only removes the first top window.
+    bool _dialog_active;
 };
 
 extern Tikzit *tikzit;


### PR DESCRIPTION
# Description
In previous implementation, when preview window is on top, pressing CMD+W on Mac will delete the mainWindow rather than the preview window. In this patch, I added a flag to mark the state of preview window being active. Then in the close action, it will look at this flag to see if it should close the preview window or the mainWindow. Thus, it will delete the preview window when it is on top, which is more natural on Mac system.