### PR TITLE
add triangle and allow node rotations

### DIFF
--- a/src/data/style.cpp
+++ b/src/data/style.cpp
@@ -198,6 +198,16 @@ QPainterPath Style::path() const
 
     if (sh == "rectangle") {
         pth.addRect(-30.0f, -30.0f, 60.0f, 60.0f);
+    } else if (sh == "triangle") {
+        QVector<QPointF> points ({
+            QPointF(-30.0f,  30.0f),
+            QPointF(  0.0f, -1.414f * 15),
+            QPointF( 30.0f,  30.0f),
+        });
+
+        QPolygonF triangle(points);
+        pth.addPolygon(triangle);
+        pth.closeSubpath();
     } else { // default is 'circle'
         pth.addEllipse(QPointF(0.0f,0.0f), 30.0f, 30.0f);
     }

--- a/src/gui/nodeitem.cpp
+++ b/src/gui/nodeitem.cpp
@@ -145,10 +145,30 @@ void NodeItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidge
 QPainterPath NodeItem::shape() const
 {
     QPainterPath path;
-
+    double rotate = _node->data()->property("rotate").toDouble();
+    QTransform transform;
+    transform.scale(GLOBAL_SCALEF, GLOBAL_SCALEF).rotate(rotate);
 	if (_node->style()->shape() == "rectangle") {
-        path.addRect(-0.2 * GLOBAL_SCALEF, -0.2 * GLOBAL_SCALEF, 0.4 * GLOBAL_SCALEF, 0.4 * GLOBAL_SCALEF);
-	} else {
+        QVector<QPointF> points ({
+            QPointF(-0.2, -0.2),
+            QPointF(-0.2,  0.2),
+            QPointF( 0.2,  0.2),
+            QPointF( 0.2, -0.2)
+        });
+        QPolygonF rect(points);
+        path.addPolygon(transform.map(rect));
+        path.closeSubpath();
+    } else if (_node->style()->shape() == "triangle") {
+        QVector<QPointF> points ({
+            QPointF(-0.2,  0.2),
+            QPointF( 0.0, -0.1464),
+            QPointF( 0.2,  0.2)
+        });
+
+        QPolygonF triangle(points);
+        path.addPolygon(transform.map(triangle));
+        path.closeSubpath();
+    } else {
         path.addEllipse(QPointF(0, 0), GLOBAL_SCALEF * 0.2, GLOBAL_SCALEF * 0.2);
 	}
     return path;

--- a/src/gui/styleeditor.ui
+++ b/src/gui/styleeditor.ui
@@ -329,6 +329,11 @@
       <string>rectangle</string>
      </property>
     </item>
+    <item>
+     <property name="text">
+      <string>triangle</string>
+     </property>
+    </item>
    </widget>
    <widget class="QCheckBox" name="hasTikzitShape">
     <property name="geometry">


### PR DESCRIPTION
This PR adds the triangle node as a shape option, and allows rectangular and triangular nodes to be rotated based node attribute information.