### PR TITLE
Allow empty value for key-value property

### DIFF
--- a/src/data/tikzparser.y
+++ b/src/data/tikzparser.y
@@ -180,6 +180,12 @@ property:
         free($3);
         $$ = p;
     }
+	| val "="
+    {
+        GraphElementProperty *p = new GraphElementProperty(QString($1),"");
+        free($1);
+        $$ = p;
+    }
 	| val
     {
         GraphElementProperty *a = new GraphElementProperty(QString($1));


### PR DESCRIPTION
Currently, if the user put nothing for the value in a property, saving the style file will give an error.

This is fixed with this pull request.

There are some cases where empty value is an allowed option (instead of an atom), e.g. `initial text=,` appears in pgfmanual.