### PR TITLE
fix preview bug arising from qt6 migration

### DIFF
--- a/src/data/pdfdocument.cpp
+++ b/src/data/pdfdocument.cpp
@@ -12,16 +12,14 @@ PdfDocument::PdfDocument(QString file, QObject *parent) : QObject(parent)
     QFile f(file);
     f.open(QIODevice::ReadOnly);
     _data = f.readAll();
-    f.reset();
-    _doc1->load(&f);
     f.close();
-    //_doc1->load(file);
+    _doc1->load(file);
 }
 
 void PdfDocument::renderTo(QLabel *label, QRect rect)
 {
     if (!isValid()) return;
-    QSizeF sz = _doc1->pagePointSize(0);
+    QSizeF sz = _doc1->pageSize(0);
     qreal w0 = sz.width();
     qreal h0 = sz.height();
     qreal ratio = label->devicePixelRatioF();
@@ -103,7 +101,7 @@ QImage PdfDocument::asImage(QSize outputSize)
 QSize PdfDocument::size()
 {
     if (isValid()) {
-        QSizeF sizef = _doc1->pagePointSize(0);
+        QSizeF sizef = _doc1->pageSize(0);
         return QSize(static_cast<int>(sizef.width()), static_cast<int>(sizef.height()));
     } else {
         return QSize();


### PR DESCRIPTION
Apply some API changes due to QT6 migration. 
`pagePointSize(0)` changed to `pageSize(0)`. (With `pagePointSize`, the program can not compile.)

There was also a pdfPreview bug, which crashes the program with segfaults when using pdfPreview. This is fixed by slight change of file handling in `PdfDocument::PdfDocument`